### PR TITLE
Make thread_count an AsyncPublisher constructor argument

### DIFF
--- a/fuse_core/include/fuse_core/async_publisher.hpp
+++ b/fuse_core/include/fuse_core/async_publisher.hpp
@@ -94,14 +94,6 @@ public:
     > interfaces,
     const std::string & name);
 
-  void initialize(
-    node_interfaces::NodeInterfaces<
-      node_interfaces::Base,
-      node_interfaces::Waitables
-    > interfaces,
-    const std::string & name,
-    size_t thread_count);
-
   /**
    * @brief Get the unique name of this publisher
    */
@@ -174,7 +166,7 @@ protected:
 
   //! A single/multi-threaded executor assigned to the local callback queue
   rclcpp::Executor::SharedPtr executor_;
-  size_t executor_thread_count_;
+  size_t executor_thread_count_{1};
   std::thread spinner_;  //!< Internal thread for spinning the executor
   std::atomic<bool> initialized_ = false;  //!< True if instance has been fully initialized
 
@@ -185,7 +177,7 @@ protected:
    *
    * @param[in] thread_count The number of threads used to service the local callback queue
    */
-  AsyncPublisher();
+  explicit AsyncPublisher(size_t thread_count = 1);
 
   /**
    * @brief Perform any required initialization for the publisher

--- a/fuse_core/include/fuse_core/async_publisher.hpp
+++ b/fuse_core/include/fuse_core/async_publisher.hpp
@@ -90,9 +90,16 @@ public:
   void initialize(
     node_interfaces::NodeInterfaces<
       node_interfaces::Base,
+      node_interfaces::Clock,
+      node_interfaces::Graph,
+      node_interfaces::Logging,
+      node_interfaces::Parameters,
+      node_interfaces::Services,
+      node_interfaces::TimeSource,
+      node_interfaces::Timers,
+      node_interfaces::Topics,
       node_interfaces::Waitables
-    > interfaces,
-    const std::string & name);
+    > interfaces, const std::string & name) override;
 
   /**
    * @brief Get the unique name of this publisher

--- a/fuse_core/include/fuse_core/publisher.hpp
+++ b/fuse_core/include/fuse_core/publisher.hpp
@@ -80,10 +80,23 @@ public:
    * conflicts and allow the same plugin to be used multiple times with different settings and
    * topics.
    *
+   * This requires all possible interfaces, but plugins may choose to use only some of them.
+   *
    * @param[in] name A unique name to give this plugin instance
    */
-  template<typename NodeT>
-  void initialize(NodeT interfaces, const std::string & name);
+  virtual void initialize(
+    node_interfaces::NodeInterfaces<
+      node_interfaces::Base,
+      node_interfaces::Clock,
+      node_interfaces::Graph,
+      node_interfaces::Logging,
+      node_interfaces::Parameters,
+      node_interfaces::Services,
+      node_interfaces::TimeSource,
+      node_interfaces::Timers,
+      node_interfaces::Topics,
+      node_interfaces::Waitables
+    > interfaces, const std::string & name) = 0;
 
   /**
    * @brief Get the unique name of this publisher

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -37,9 +37,9 @@
 namespace fuse_core
 {
 
-AsyncPublisher::AsyncPublisher()
+AsyncPublisher::AsyncPublisher(size_t thread_count)
 : name_("uninitialized"),
-  executor_thread_count_(1)
+  executor_thread_count_(thread_count)
 {
 }
 
@@ -108,18 +108,6 @@ void AsyncPublisher::initialize(
   auto result = callback->getFuture();
   callback_queue_->addCallback(callback);
   result.wait();
-}
-
-void AsyncPublisher::initialize(
-  node_interfaces::NodeInterfaces<
-    node_interfaces::Base,
-    node_interfaces::Waitables
-  > interfaces,
-  const std::string & name,
-  size_t thread_count)
-{
-  executor_thread_count_ = thread_count;
-  initialize(interfaces, name);
 }
 
 void AsyncPublisher::notify(Transaction::ConstSharedPtr transaction, Graph::ConstSharedPtr graph)

--- a/fuse_core/src/async_publisher.cpp
+++ b/fuse_core/src/async_publisher.cpp
@@ -51,6 +51,14 @@ AsyncPublisher::~AsyncPublisher()
 void AsyncPublisher::initialize(
   node_interfaces::NodeInterfaces<
     node_interfaces::Base,
+    node_interfaces::Clock,
+    node_interfaces::Graph,
+    node_interfaces::Logging,
+    node_interfaces::Parameters,
+    node_interfaces::Services,
+    node_interfaces::TimeSource,
+    node_interfaces::Timers,
+    node_interfaces::Topics,
     node_interfaces::Waitables
   > interfaces,
   const std::string & name)

--- a/fuse_core/test/test_async_publisher.cpp
+++ b/fuse_core/test/test_async_publisher.cpp
@@ -89,7 +89,7 @@ TEST_F(TestAsyncPublisher, OnInit)
   for (int i = 0; i < 50; i++) {
     auto node = rclcpp::Node::make_shared("test_async_pub_node");
     MyPublisher publisher;
-    publisher.initialize(node, "my_publisher_" + std::to_string(i), 0);
+    publisher.initialize(node, "my_publisher_" + std::to_string(i));
     EXPECT_TRUE(publisher.initialized);
   }
 }
@@ -98,16 +98,16 @@ TEST_F(TestAsyncPublisher, DoubleInit)
 {
   auto node = rclcpp::Node::make_shared("test_async_pub_node");
   MyPublisher publisher;
-  publisher.initialize(node, "my_publisher", 0);
+  publisher.initialize(node, "my_publisher");
   EXPECT_TRUE(publisher.initialized);
-  EXPECT_THROW(publisher.initialize(node, "test", 0), std::runtime_error);
+  EXPECT_THROW(publisher.initialize(node, "test"), std::runtime_error);
 }
 
 TEST_F(TestAsyncPublisher, notifyCallback)
 {
   auto node = rclcpp::Node::make_shared("test_async_pub_node");
   MyPublisher publisher;
-  publisher.initialize(node, "my_publisher", 0);
+  publisher.initialize(node, "my_publisher");
 
   // Execute the notify() method in this thread. This should push a call to
   // MyPublisher::notifyCallback() into MyPublisher's callback queue, which will get executed by

--- a/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
@@ -80,11 +80,17 @@ public:
   void initialize(
     fuse_core::node_interfaces::NodeInterfaces<
       fuse_core::node_interfaces::Base,
+      fuse_core::node_interfaces::Clock,
+      fuse_core::node_interfaces::Graph,
+      fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters,
+      fuse_core::node_interfaces::Services,
+      fuse_core::node_interfaces::TimeSource,
+      fuse_core::node_interfaces::Timers,
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name);
+    const std::string & name) override;
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
@@ -84,8 +84,7 @@ public:
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name,
-    size_t thread_count);
+    const std::string & name);
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -128,14 +128,16 @@ public:
     fuse_core::node_interfaces::NodeInterfaces<
       fuse_core::node_interfaces::Base,
       fuse_core::node_interfaces::Clock,
+      fuse_core::node_interfaces::Graph,
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters,
       fuse_core::node_interfaces::Services,
+      fuse_core::node_interfaces::TimeSource,
       fuse_core::node_interfaces::Timers,
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name);
+    const std::string & name) override;
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -135,8 +135,7 @@ public:
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name,
-    size_t thread_count);
+    const std::string & name);
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -76,12 +76,16 @@ public:
     fuse_core::node_interfaces::NodeInterfaces<
       fuse_core::node_interfaces::Base,
       fuse_core::node_interfaces::Clock,
+      fuse_core::node_interfaces::Graph,
       fuse_core::node_interfaces::Logging,
       fuse_core::node_interfaces::Parameters,
+      fuse_core::node_interfaces::Services,
+      fuse_core::node_interfaces::TimeSource,
+      fuse_core::node_interfaces::Timers,
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name);
+    const std::string & name) override;
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -81,8 +81,7 @@ public:
       fuse_core::node_interfaces::Topics,
       fuse_core::node_interfaces::Waitables
     > interfaces,
-    const std::string & name,
-    size_t thread_count);
+    const std::string & name);
 
   /**
    * @brief Perform any required post-construction initialization, such as advertising publishers or reading from the

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -61,7 +61,7 @@ namespace fuse_publishers
 {
 
 Path2DPublisher::Path2DPublisher() :
-  fuse_core::AsyncPublisher(),
+  fuse_core::AsyncPublisher(1),
   device_id_(fuse_core::uuid::NIL),
   frame_id_("map")
 {
@@ -74,11 +74,10 @@ void Path2DPublisher::initialize(
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
   > interfaces,
-  const std::string & name,
-  size_t thread_count)
+  const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name, thread_count);
+  fuse_core::AsyncPublisher::initialize(interfaces_, name);
 }
 
 void Path2DPublisher::onInit()

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -70,14 +70,20 @@ Path2DPublisher::Path2DPublisher() :
 void Path2DPublisher::initialize(
   fuse_core::node_interfaces::NodeInterfaces<
     fuse_core::node_interfaces::Base,
+    fuse_core::node_interfaces::Clock,
+    fuse_core::node_interfaces::Graph,
+    fuse_core::node_interfaces::Logging,
     fuse_core::node_interfaces::Parameters,
+    fuse_core::node_interfaces::Services,
+    fuse_core::node_interfaces::TimeSource,
+    fuse_core::node_interfaces::Timers,
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
   > interfaces,
   const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name);
+  fuse_core::AsyncPublisher::initialize(interfaces, name);
 }
 
 void Path2DPublisher::onInit()

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -122,9 +122,11 @@ void Pose2DPublisher::initialize(
   fuse_core::node_interfaces::NodeInterfaces<
     fuse_core::node_interfaces::Base,
     fuse_core::node_interfaces::Clock,
+    fuse_core::node_interfaces::Graph,
     fuse_core::node_interfaces::Logging,
     fuse_core::node_interfaces::Parameters,
     fuse_core::node_interfaces::Services,
+    fuse_core::node_interfaces::TimeSource,
     fuse_core::node_interfaces::Timers,
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
@@ -132,7 +134,7 @@ void Pose2DPublisher::initialize(
   const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name);
+  fuse_core::AsyncPublisher::initialize(interfaces, name);
 }
 
 void Pose2DPublisher::onInit()

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -109,7 +109,7 @@ namespace fuse_publishers
 {
 
 Pose2DPublisher::Pose2DPublisher() :
-  fuse_core::AsyncPublisher(),
+  fuse_core::AsyncPublisher(1),
   device_id_(fuse_core::uuid::NIL),
   logger_(rclcpp::get_logger("uninitialized")),
   publish_to_tf_(false),
@@ -129,11 +129,10 @@ void Pose2DPublisher::initialize(
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
   > interfaces,
-  const std::string & name,
-  size_t thread_count)
+  const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name, thread_count);
+  fuse_core::AsyncPublisher::initialize(interfaces_, name);
 }
 
 void Pose2DPublisher::onInit()

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -52,7 +52,7 @@ namespace fuse_publishers
 {
 
 SerializedPublisher::SerializedPublisher() :
-  fuse_core::AsyncPublisher(),
+  fuse_core::AsyncPublisher(1),
   frame_id_("map"),
   graph_publisher_throttled_callback_(
       std::bind(&SerializedPublisher::graphPublisherCallback, this, std::placeholders::_1, std::placeholders::_2))
@@ -68,11 +68,10 @@ void SerializedPublisher::initialize(
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
   > interfaces,
-  const std::string & name,
-  size_t thread_count)
+  const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name, thread_count);
+  fuse_core::AsyncPublisher::initialize(interfaces_, name);
 }
 
 void SerializedPublisher::onInit()

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -63,15 +63,19 @@ void SerializedPublisher::initialize(
   fuse_core::node_interfaces::NodeInterfaces<
     fuse_core::node_interfaces::Base,
     fuse_core::node_interfaces::Clock,
+    fuse_core::node_interfaces::Graph,
     fuse_core::node_interfaces::Logging,
     fuse_core::node_interfaces::Parameters,
+    fuse_core::node_interfaces::Services,
+    fuse_core::node_interfaces::TimeSource,
+    fuse_core::node_interfaces::Timers,
     fuse_core::node_interfaces::Topics,
     fuse_core::node_interfaces::Waitables
   > interfaces,
   const std::string & name)
 {
   interfaces_ = interfaces;
-  fuse_core::AsyncPublisher::initialize(interfaces_, name);
+  fuse_core::AsyncPublisher::initialize(interfaces, name);
 }
 
 void SerializedPublisher::onInit()

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -216,7 +216,7 @@ TEST_F(Path2DPublisherTestFixture, PublishPath)
   fuse_publishers::Path2DPublisher publisher;
 
   // This is the name of the pub's inner node (to set params against)
-  publisher.initialize(node, "test_publisher", 0);
+  publisher.initialize(node, "test_publisher");
   publisher.start();
 
   // Subscribe to the "path" topic

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -223,7 +223,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPose)
 
   // Create a publisher and send it the graph
   fuse_publishers::Pose2DPublisher publisher;
-  publisher.initialize(node, "test_publisher", 0);
+  publisher.initialize(node, "test_publisher");
   publisher.start();
 
   // Subscribe to the "pose" topic
@@ -265,7 +265,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPoseWithCovariance)
 
   // Create a publisher and send it the graph
   fuse_publishers::Pose2DPublisher publisher;
-  publisher.initialize(node, "test_publisher", 0);
+  publisher.initialize(node, "test_publisher");
   publisher.start();
 
   // Subscribe to the "pose_with_covariance" topic
@@ -332,7 +332,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithoutOdom)
 
   // Create a publisher and send it the graph
   fuse_publishers::Pose2DPublisher publisher;
-  publisher.initialize(node, "test_publisher", 0);
+  publisher.initialize(node, "test_publisher");
   publisher.start();
 
   // Send the graph to the Publisher to trigger message publishing
@@ -380,7 +380,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithOdom)
 
   // Create a publisher and send it the graph
   fuse_publishers::Pose2DPublisher publisher;
-  publisher.initialize(node, "test_publisher", 0);
+  publisher.initialize(node, "test_publisher");
   publisher.start();
 
   // Send the graph to the Publisher to trigger message publishing


### PR DESCRIPTION
I think this more closely aligns with what the ROS 1 code is doing. I think sensor models and motion models will need similar changes.  I don't see any linker errors or test failures (except linters) with these changes.

In ROS 1
* `AsyncPublisher` [has an explicit constructor that allows specifying the number of threads](https://github.com/locusrobotics/fuse/blob/0461f779f9ac4defca6ecfd102a675add92bb3a9/fuse_core/include/fuse_core/async_publisher.h#L149)
* subclasses of `AsyncPublisher` [choose how many threads they need](https://github.com/locusrobotics/fuse/blob/0461f779f9ac4defca6ecfd102a675add92bb3a9/fuse_publishers/src/path_2d_publisher.cpp#L62)
