### PR TITLE
Reduce timeouts to 10s

### DIFF
--- a/fuse_core/include/fuse_core/async_publisher.hpp
+++ b/fuse_core/include/fuse_core/async_publisher.hpp
@@ -88,18 +88,8 @@ public:
    * @throws runtime_error if already initialized
    */
   void initialize(
-    node_interfaces::NodeInterfaces<
-      node_interfaces::Base,
-      node_interfaces::Clock,
-      node_interfaces::Graph,
-      node_interfaces::Logging,
-      node_interfaces::Parameters,
-      node_interfaces::Services,
-      node_interfaces::TimeSource,
-      node_interfaces::Timers,
-      node_interfaces::Topics,
-      node_interfaces::Waitables
-    > interfaces, const std::string & name) override;
+    node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
+    const std::string & name) override;
 
   /**
    * @brief Get the unique name of this publisher

--- a/fuse_core/include/fuse_core/node_interfaces/node_interfaces.hpp
+++ b/fuse_core/include/fuse_core/node_interfaces/node_interfaces.hpp
@@ -19,6 +19,19 @@
 
 #include "fuse_core/node_interfaces/node_interfaces_helpers.hpp"
 
+#define ALL_RCLCPP_NODE_INTERFACES \
+  fuse_core::node_interfaces::Base, \
+  fuse_core::node_interfaces::Clock, \
+  fuse_core::node_interfaces::Graph, \
+  fuse_core::node_interfaces::Logging, \
+  fuse_core::node_interfaces::Parameters, \
+  fuse_core::node_interfaces::Services, \
+  fuse_core::node_interfaces::TimeSource, \
+  fuse_core::node_interfaces::Timers, \
+  fuse_core::node_interfaces::Topics, \
+  fuse_core::node_interfaces::Waitables
+
+
 namespace fuse_core
 {
 namespace node_interfaces

--- a/fuse_core/include/fuse_core/publisher.hpp
+++ b/fuse_core/include/fuse_core/publisher.hpp
@@ -85,18 +85,8 @@ public:
    * @param[in] name A unique name to give this plugin instance
    */
   virtual void initialize(
-    node_interfaces::NodeInterfaces<
-      node_interfaces::Base,
-      node_interfaces::Clock,
-      node_interfaces::Graph,
-      node_interfaces::Logging,
-      node_interfaces::Parameters,
-      node_interfaces::Services,
-      node_interfaces::TimeSource,
-      node_interfaces::Timers,
-      node_interfaces::Topics,
-      node_interfaces::Waitables
-    > interfaces, const std::string & name) = 0;
+    node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
+    const std::string & name) = 0;
 
   /**
    * @brief Get the unique name of this publisher

--- a/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/path_2d_publisher.h
@@ -78,18 +78,7 @@ public:
    * @brief Shadowing extension to the AsyncPublisher::initialize call
    */
   void initialize(
-    fuse_core::node_interfaces::NodeInterfaces<
-      fuse_core::node_interfaces::Base,
-      fuse_core::node_interfaces::Clock,
-      fuse_core::node_interfaces::Graph,
-      fuse_core::node_interfaces::Logging,
-      fuse_core::node_interfaces::Parameters,
-      fuse_core::node_interfaces::Services,
-      fuse_core::node_interfaces::TimeSource,
-      fuse_core::node_interfaces::Timers,
-      fuse_core::node_interfaces::Topics,
-      fuse_core::node_interfaces::Waitables
-    > interfaces,
+    fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
     const std::string & name) override;
 
   /**

--- a/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/pose_2d_publisher.h
@@ -125,18 +125,7 @@ public:
    * @brief Shadowing extension to the AsyncPublisher::initialize call
    */
   void initialize(
-    fuse_core::node_interfaces::NodeInterfaces<
-      fuse_core::node_interfaces::Base,
-      fuse_core::node_interfaces::Clock,
-      fuse_core::node_interfaces::Graph,
-      fuse_core::node_interfaces::Logging,
-      fuse_core::node_interfaces::Parameters,
-      fuse_core::node_interfaces::Services,
-      fuse_core::node_interfaces::TimeSource,
-      fuse_core::node_interfaces::Timers,
-      fuse_core::node_interfaces::Topics,
-      fuse_core::node_interfaces::Waitables
-    > interfaces,
+    fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
     const std::string & name) override;
 
   /**

--- a/fuse_publishers/include/fuse_publishers/serialized_publisher.h
+++ b/fuse_publishers/include/fuse_publishers/serialized_publisher.h
@@ -73,18 +73,7 @@ public:
    * @brief Shadowing extension to the AsyncPublisher::initialize call
    */
   void initialize(
-    fuse_core::node_interfaces::NodeInterfaces<
-      fuse_core::node_interfaces::Base,
-      fuse_core::node_interfaces::Clock,
-      fuse_core::node_interfaces::Graph,
-      fuse_core::node_interfaces::Logging,
-      fuse_core::node_interfaces::Parameters,
-      fuse_core::node_interfaces::Services,
-      fuse_core::node_interfaces::TimeSource,
-      fuse_core::node_interfaces::Timers,
-      fuse_core::node_interfaces::Topics,
-      fuse_core::node_interfaces::Waitables
-    > interfaces,
+    fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
     const std::string & name) override;
 
   /**

--- a/fuse_publishers/src/path_2d_publisher.cpp
+++ b/fuse_publishers/src/path_2d_publisher.cpp
@@ -68,18 +68,7 @@ Path2DPublisher::Path2DPublisher() :
 }
 
 void Path2DPublisher::initialize(
-  fuse_core::node_interfaces::NodeInterfaces<
-    fuse_core::node_interfaces::Base,
-    fuse_core::node_interfaces::Clock,
-    fuse_core::node_interfaces::Graph,
-    fuse_core::node_interfaces::Logging,
-    fuse_core::node_interfaces::Parameters,
-    fuse_core::node_interfaces::Services,
-    fuse_core::node_interfaces::TimeSource,
-    fuse_core::node_interfaces::Timers,
-    fuse_core::node_interfaces::Topics,
-    fuse_core::node_interfaces::Waitables
-  > interfaces,
+  fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
   const std::string & name)
 {
   interfaces_ = interfaces;

--- a/fuse_publishers/src/pose_2d_publisher.cpp
+++ b/fuse_publishers/src/pose_2d_publisher.cpp
@@ -119,18 +119,7 @@ Pose2DPublisher::Pose2DPublisher() :
 }
 
 void Pose2DPublisher::initialize(
-  fuse_core::node_interfaces::NodeInterfaces<
-    fuse_core::node_interfaces::Base,
-    fuse_core::node_interfaces::Clock,
-    fuse_core::node_interfaces::Graph,
-    fuse_core::node_interfaces::Logging,
-    fuse_core::node_interfaces::Parameters,
-    fuse_core::node_interfaces::Services,
-    fuse_core::node_interfaces::TimeSource,
-    fuse_core::node_interfaces::Timers,
-    fuse_core::node_interfaces::Topics,
-    fuse_core::node_interfaces::Waitables
-  > interfaces,
+  fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
   const std::string & name)
 {
   interfaces_ = interfaces;

--- a/fuse_publishers/src/serialized_publisher.cpp
+++ b/fuse_publishers/src/serialized_publisher.cpp
@@ -60,18 +60,7 @@ SerializedPublisher::SerializedPublisher() :
 }
 
 void SerializedPublisher::initialize(
-  fuse_core::node_interfaces::NodeInterfaces<
-    fuse_core::node_interfaces::Base,
-    fuse_core::node_interfaces::Clock,
-    fuse_core::node_interfaces::Graph,
-    fuse_core::node_interfaces::Logging,
-    fuse_core::node_interfaces::Parameters,
-    fuse_core::node_interfaces::Services,
-    fuse_core::node_interfaces::TimeSource,
-    fuse_core::node_interfaces::Timers,
-    fuse_core::node_interfaces::Topics,
-    fuse_core::node_interfaces::Waitables
-  > interfaces,
+  fuse_core::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES> interfaces,
   const std::string & name)
 {
   interfaces_ = interfaces;

--- a/fuse_publishers/test/test_path_2d_publisher.cpp
+++ b/fuse_publishers/test/test_path_2d_publisher.cpp
@@ -233,7 +233,7 @@ TEST_F(Path2DPublisherTestFixture, PublishPath)
   publisher.notify(transaction_, graph_);
 
   // Verify the subscriber received the expected pose
-  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(20.0);
+  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(10.0);
   while ((!received_path_msg_) && (node->now() < timeout))
   {
     rclcpp::sleep_for(rclcpp::Duration::from_seconds(0.10).to_chrono<std::chrono::nanoseconds>());

--- a/fuse_publishers/test/test_pose_2d_publisher.cpp
+++ b/fuse_publishers/test/test_pose_2d_publisher.cpp
@@ -235,7 +235,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPose)
   publisher.notify(transaction_, graph_);
 
   // Verify the subscriber received the expected pose
-  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(20.0);
+  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(10.0);
   while ((!received_pose_msg_) && (node->now() < timeout))
   {
     rclcpp::sleep_for(rclcpp::Duration::from_seconds(0.10).to_chrono<std::chrono::nanoseconds>());
@@ -277,7 +277,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishPoseWithCovariance)
   publisher.notify(transaction_, graph_);
 
   // Verify the subscriber received the expected pose
-  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(20.0);
+  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(10.0);
   while ((!received_pose_with_covariance_msg_) && (node->now() < timeout))
   {
     rclcpp::sleep_for(rclcpp::Duration::from_seconds(0.10).to_chrono<std::chrono::nanoseconds>());
@@ -339,7 +339,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithoutOdom)
   publisher.notify(transaction_, graph_);
 
   // Verify the subscriber received the expected pose
-  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(20.0);
+  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(10.0);
   while ((!received_tf_msg_) && (node->now() < timeout))
   {
     rclcpp::sleep_for(rclcpp::Duration::from_seconds(0.10).to_chrono<std::chrono::nanoseconds>());
@@ -387,7 +387,7 @@ TEST_F(Pose2DPublisherTestFixture, PublishTfWithOdom)
   publisher.notify(transaction_, graph_);
 
   // Verify the subscriber received the expected pose
-  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(20.0);
+  rclcpp::Time timeout = node->now() + rclcpp::Duration::from_seconds(10.0);
   while ((!received_tf_msg_) && (node->now() < timeout))
   {
     rclcpp::sleep_for(rclcpp::Duration::from_seconds(0.10).to_chrono<std::chrono::nanoseconds>());


### PR DESCRIPTION
The values that were used in ROS 1 versions of these tests

context: https://github.com/locusrobotics/fuse/pull/299#discussion_r1058683548