### PR TITLE
Remove need for sensor_model_list, motion_model_list, and publisher_list

### DIFF
--- a/fuse_core/CMakeLists.txt
+++ b/fuse_core/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(${PROJECT_NAME}
   src/graph.cpp
   src/graph_deserializer.cpp
   src/loss.cpp
+  src/parameter.cpp
   src/serialization.cpp
   src/time.cpp
   src/timestamp_manager.cpp

--- a/fuse_core/include/fuse_core/parameter.hpp
+++ b/fuse_core/include/fuse_core/parameter.hpp
@@ -34,6 +34,7 @@
 #ifndef FUSE_CORE__PARAMETER_HPP_
 #define FUSE_CORE__PARAMETER_HPP_
 
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -125,31 +126,43 @@ T getParam(
   }
 }
 
-namespace detail {
+namespace detail
+{
 /** @brief Internal function for unit testing.
  * @internal
 */
 std::unordered_set<std::string>
-list_parameter_overrides_at_prefix(
+list_parameter_override_prefixes(
   const std::map<std::string, rclcpp::ParameterValue> & overrides,
-  std::string prefix, size_t depth);
+  std::string prefix);
 }  // namespace detail
 
 /**
- * @brief Get pararameter overrides that exist at a given prefix.
- * 
+ * @brief Get pararameter overrides that have a given prefix
+ *
  * Example:
- *  Say the given parameter overrides are foo, foo.bar, foo.bar.baz, and foobar.baz
- *  Given prefix "foo" and depth 0, this will return foo.bar and foo.bar.baz
- *  Given prefix "foo" and depth 1, this will return foo.bar
- * 
+ *  Say the given parameter overrides are foo, foo.baz, foo.bar.baz, and foobar.baz
+ *  Given prefix "", this will return foo, and foobar
+ *  Given prefix "foo", this will return foo.baz and foo.bar
+ *  Given prefix "foo.bar", this will return foo.bar.baz
+ *  Given prefix "foo.baz", this will return an empty list
+ *
+ *  All overrides are searched and returned, so that this can be used to
+ *  conditionally declare parameters.
+ *  The returned names may or may not be valid parameters, but instead are
+ *  prefixes of valid parameters.
+ *  The prefix itself will never be in the returned output.
+ *
+ *
  * @param[in] interfaces - The node interfaces used to get the parameter overrides
- * @param[in] prefix - the name of a parameter 
+ * @param[in] prefix - the parameter prefix
+ * @param[in] max_depth - how deep to return parameter override names, or 0 for
+ *    unlimited depth.
 */
 std::unordered_set<std::string>
-list_parameter_overrides_at_prefix(
+list_parameter_override_prefixes(
   node_interfaces::NodeInterfaces<node_interfaces::Parameters> interfaces,
-  std::string prefix, size_t depth = 0);
+  std::string prefix);
 
 /**
  * @brief Utility method for handling required ROS params

--- a/fuse_core/include/fuse_core/parameter.hpp
+++ b/fuse_core/include/fuse_core/parameter.hpp
@@ -138,7 +138,7 @@ list_parameter_override_prefixes(
 }  // namespace detail
 
 /**
- * @brief Get pararameter overrides that have a given prefix
+ * @brief Get parameter overrides that have a given prefix
  *
  * Example:
  *  Say the given parameter overrides are foo, foo.baz, foo.bar.baz, and foobar.baz

--- a/fuse_core/include/fuse_core/parameter.hpp
+++ b/fuse_core/include/fuse_core/parameter.hpp
@@ -36,6 +36,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <fuse_core/eigen.hpp>
@@ -123,6 +124,32 @@ T getParam(
     throw rclcpp::exceptions::InvalidParameterTypeException(parameter_name, ex.what());
   }
 }
+
+namespace detail {
+/** @brief Internal function for unit testing.
+ * @internal
+*/
+std::unordered_set<std::string>
+list_parameter_overrides_at_prefix(
+  const std::map<std::string, rclcpp::ParameterValue> & overrides,
+  std::string prefix, size_t depth);
+}  // namespace detail
+
+/**
+ * @brief Get pararameter overrides that exist at a given prefix.
+ * 
+ * Example:
+ *  Say the given parameter overrides are foo, foo.bar, foo.bar.baz, and foobar.baz
+ *  Given prefix "foo" and depth 0, this will return foo.bar and foo.bar.baz
+ *  Given prefix "foo" and depth 1, this will return foo.bar
+ * 
+ * @param[in] interfaces - The node interfaces used to get the parameter overrides
+ * @param[in] prefix - the name of a parameter 
+*/
+std::unordered_set<std::string>
+list_parameter_overrides_at_prefix(
+  node_interfaces::NodeInterfaces<node_interfaces::Parameters> interfaces,
+  std::string prefix, size_t depth = 0);
 
 /**
  * @brief Utility method for handling required ROS params

--- a/fuse_core/src/parameter.cpp
+++ b/fuse_core/src/parameter.cpp
@@ -1,0 +1,94 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Locus Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <fuse_core/parameter.hpp>
+
+#include <cassert>
+#include <string>
+#include <unordered_set>
+
+
+namespace fuse_core
+{
+std::unordered_set<std::string>
+list_parameter_overrides_at_prefix(
+  node_interfaces::NodeInterfaces<node_interfaces::Parameters> interfaces,
+  std::string prefix, size_t depth)
+{
+  const std::map<std::string, rclcpp::ParameterValue> & overrides =
+      interfaces.get_node_parameters_interface()->get_parameter_overrides();
+  return detail::list_parameter_overrides_at_prefix(overrides, prefix, depth);
+}
+
+std::unordered_set<std::string>
+detail::list_parameter_overrides_at_prefix(
+  const std::map<std::string, rclcpp::ParameterValue> & overrides,
+  std::string prefix, size_t depth)
+{
+  // TODO(sloretz) ROS 2 must have this in a header somewhere, right?
+  const char kParamSeparator = '.';
+
+  // Find all overrides starting with "prefix.", unless the prefix is empty.
+  // If the prefix is empty then return all parameter overrides.
+  if (!prefix.empty() && prefix.back() != kParamSeparator) {
+    prefix += kParamSeparator;
+  }
+
+  std::unordered_set<std::string> output_names;
+  for (const auto & kv : overrides) {
+    const std::string & name = kv.first;
+    if (name.size() <= prefix.size()) {
+      // Too short, no point in checking
+      continue;
+    }
+    assert(prefix.size() < name.size());
+    // TODO(sloretz) use string::starts_with in c++20
+    if (name.rfind(prefix, 0) == 0) {  // if name starts with prefix
+      if (depth == 0) {
+        // If not using depth, add the name no matter what
+        output_names.insert(name);
+      } else {
+        // Truncate names to at most the requested depth
+        size_t separator_pos = name.find(kParamSeparator, prefix.size());
+        for (size_t l = depth; l > 0 && separator_pos != std::string::npos; --l) {
+          separator_pos = name.find(kParamSeparator, separator_pos);
+        }
+        // Insert truncated name
+        output_names.insert(name.substr(0, separator_pos));
+      }
+    }
+  }
+  return output_names;
+}
+}  // namespace fuse_core

--- a/fuse_core/src/parameter.cpp
+++ b/fuse_core/src/parameter.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2018, Locus Robotics
+ *  Copyright (c) 2023, Intrinsic.ai
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/fuse_core/src/parameter.cpp
+++ b/fuse_core/src/parameter.cpp
@@ -42,25 +42,25 @@
 namespace fuse_core
 {
 std::unordered_set<std::string>
-list_parameter_overrides_at_prefix(
+list_parameter_override_prefixes(
   node_interfaces::NodeInterfaces<node_interfaces::Parameters> interfaces,
-  std::string prefix, size_t depth)
+  std::string prefix)
 {
   const std::map<std::string, rclcpp::ParameterValue> & overrides =
-      interfaces.get_node_parameters_interface()->get_parameter_overrides();
-  return detail::list_parameter_overrides_at_prefix(overrides, prefix, depth);
+    interfaces.get_node_parameters_interface()->get_parameter_overrides();
+  return detail::list_parameter_override_prefixes(overrides, prefix);
 }
 
 std::unordered_set<std::string>
-detail::list_parameter_overrides_at_prefix(
+detail::list_parameter_override_prefixes(
   const std::map<std::string, rclcpp::ParameterValue> & overrides,
-  std::string prefix, size_t depth)
+  std::string prefix)
 {
   // TODO(sloretz) ROS 2 must have this in a header somewhere, right?
   const char kParamSeparator = '.';
 
   // Find all overrides starting with "prefix.", unless the prefix is empty.
-  // If the prefix is empty then return all parameter overrides.
+  // If the prefix is empty then look at all parameter overrides.
   if (!prefix.empty() && prefix.back() != kParamSeparator) {
     prefix += kParamSeparator;
   }
@@ -75,18 +75,10 @@ detail::list_parameter_overrides_at_prefix(
     assert(prefix.size() < name.size());
     // TODO(sloretz) use string::starts_with in c++20
     if (name.rfind(prefix, 0) == 0) {  // if name starts with prefix
-      if (depth == 0) {
-        // If not using depth, add the name no matter what
-        output_names.insert(name);
-      } else {
-        // Truncate names to at most the requested depth
-        size_t separator_pos = name.find(kParamSeparator, prefix.size());
-        for (size_t l = depth; l > 0 && separator_pos != std::string::npos; --l) {
-          separator_pos = name.find(kParamSeparator, separator_pos);
-        }
-        // Insert truncated name
-        output_names.insert(name.substr(0, separator_pos));
-      }
+      // Truncate names to the next separator
+      size_t separator_pos = name.find(kParamSeparator, prefix.size());
+      // Insert truncated name
+      output_names.insert(name.substr(0, separator_pos));
     }
   }
   return output_names;

--- a/fuse_core/test/CMakeLists.txt
+++ b/fuse_core/test/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(test_loss ${PROJECT_NAME})
 ament_add_gtest(test_message_buffer test_message_buffer.cpp)
 target_link_libraries(test_message_buffer ${PROJECT_NAME})
 
+ament_add_gtest(test_parameter test_parameter.cpp)
+target_link_libraries(test_parameter ${PROJECT_NAME})
+
 ament_add_gtest(test_timestamp_manager test_timestamp_manager.cpp)
 target_link_libraries(test_timestamp_manager ${PROJECT_NAME})
 

--- a/fuse_core/test/test_parameter.cpp
+++ b/fuse_core/test/test_parameter.cpp
@@ -39,42 +39,59 @@
 
 #include <fuse_core/parameter.hpp>
 
-TEST(parameter, list_parameter_overrides)
+TEST(parameter, list_parameter_override_prefixes)
 {
   const std::map<std::string, rclcpp::ParameterValue> overrides = {
     {"foo", {}},
+    {"foo.baz", {}},
     {"foo.bar", {}},
     {"foo.bar.baz", {}},
+    {"foo.bar.baz.bing", {}},
     {"foobar.baz", {}},
+    {"baz", {}}
   };
 
   {
-    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
-        overrides, "foo", 0);
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "foo");
     EXPECT_EQ(2u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo.baz"));
     EXPECT_NE(matches.end(), matches.find("foo.bar"));
-    EXPECT_NE(matches.end(), matches.find("foo.bar.baz"));
   }
   {
-    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
-        overrides, "foo", 1);
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "foo.bar");
     EXPECT_EQ(1u, matches.size());
-    EXPECT_NE(matches.end(), matches.find("foo.bar"));
+    EXPECT_NE(matches.end(), matches.find("foo.bar.baz"));
   }
   {
-    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
-        overrides, "", 0);
-    EXPECT_EQ(4u, matches.size());
-    EXPECT_NE(matches.end(), matches.find("foo"));
-    EXPECT_NE(matches.end(), matches.find("foo.bar"));
-    EXPECT_NE(matches.end(), matches.find("foo.bar.baz"));
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "foo.bar.baz");
+    EXPECT_EQ(1u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo.bar.baz.bing"));
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "foo.baz");
+    EXPECT_EQ(0u, matches.size());
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "foobar");
+    EXPECT_EQ(1u, matches.size());
     EXPECT_NE(matches.end(), matches.find("foobar.baz"));
   }
   {
-    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
-        overrides, "", 1);
-    EXPECT_EQ(2u, matches.size());
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "dne");
+    EXPECT_EQ(0u, matches.size());
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_override_prefixes(
+      overrides, "");
+    EXPECT_EQ(3u, matches.size());
     EXPECT_NE(matches.end(), matches.find("foo"));
     EXPECT_NE(matches.end(), matches.find("foobar"));
+    EXPECT_NE(matches.end(), matches.find("baz"));
   }
 }

--- a/fuse_core/test/test_parameter.cpp
+++ b/fuse_core/test/test_parameter.cpp
@@ -1,0 +1,80 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Intrinsic.ai
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <map>
+#include <string>
+
+#include <fuse_core/parameter.hpp>
+
+TEST(parameter, list_parameter_overrides)
+{
+  const std::map<std::string, rclcpp::ParameterValue> overrides = {
+    {"foo", {}},
+    {"foo.bar", {}},
+    {"foo.bar.baz", {}},
+    {"foobar.baz", {}},
+  };
+
+  {
+    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
+        overrides, "foo", 0);
+    EXPECT_EQ(2u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo.bar"));
+    EXPECT_NE(matches.end(), matches.find("foo.bar.baz"));
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
+        overrides, "foo", 1);
+    EXPECT_EQ(1u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo.bar"));
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
+        overrides, "", 0);
+    EXPECT_EQ(4u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo"));
+    EXPECT_NE(matches.end(), matches.find("foo.bar"));
+    EXPECT_NE(matches.end(), matches.find("foo.bar.baz"));
+    EXPECT_NE(matches.end(), matches.find("foobar.baz"));
+  }
+  {
+    auto matches = fuse_core::detail::list_parameter_overrides_at_prefix(
+        overrides, "", 1);
+    EXPECT_EQ(2u, matches.size());
+    EXPECT_NE(matches.end(), matches.find("foo"));
+    EXPECT_NE(matches.end(), matches.find("foobar"));
+  }
+}

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -34,6 +34,7 @@
 
 #include <fuse_core/callback_wrapper.hpp>
 #include <fuse_core/graph.hpp>
+#include <fuse_core/parameter.hpp>
 #include <fuse_core/time.hpp>
 #include <fuse_core/transaction.hpp>
 #include <fuse_core/uuid.hpp>
@@ -109,9 +110,6 @@ Optimizer::~Optimizer()
 
 void Optimizer::loadMotionModels()
 {
-  const std::string param_prefix = "motion_models.";
-  const std::string list_param_full_name = param_prefix + "motion_model_list";
-
   // struct for readability
   typedef struct {
     std::string name;
@@ -122,34 +120,15 @@ void Optimizer::loadMotionModels()
   // the configurations used to load models
   std::vector<ModelConfig> motion_model_config;
 
-  // declare the parameter
-  if(! interfaces_.get_node_parameters_interface()->has_parameter(list_param_full_name)){
-    rcl_interfaces::msg::ParameterDescriptor descr;
-    descr.description = "the list of motion models to load";
-    interfaces_.get_node_parameters_interface()->declare_parameter(
-      list_param_full_name,
-      rclcpp::ParameterValue (std::vector< std::string >()),
-      descr
-    );
-    // XXX catch rclcpp::exceptions::InvalidParameterValueException when launch assigns wrong type
-  }
-
-  // get the list of motion models
-  rclcpp::Parameter motion_model_list_param = interfaces_.get_node_parameters_interface()->get_parameter(list_param_full_name);
-
-  //extract the list from the parameter
-  if(motion_model_list_param.get_type() == rclcpp::ParameterType::PARAMETER_STRING_ARRAY){
-    std::vector< std::string > names = motion_model_list_param.as_string_array();
-    for(std::string name : names){
-      ModelConfig config;
-      config.name = name;
-      motion_model_config.push_back(std::move(config));
-    }
-  }
+  std::unordered_set<std::string> motion_model_names =
+    fuse_core::list_parameter_overrides_at_prefix(
+      interfaces_, "motion_models.", 1);
 
   // declare config parameters for each model
-  for(ModelConfig & config : motion_model_config){
-    config.param_name = param_prefix + config.name + ".type";
+  for(const auto & param_name : motion_model_names){
+    ModelConfig & config = motion_model_config.emplace_back();
+    config.name = param_name.substr(param_name.rfind('.') + 1);
+    config.param_name = param_name + ".type";
 
     if(! interfaces_.get_node_parameters_interface()->has_parameter(config.param_name)){
       rcl_interfaces::msg::ParameterDescriptor descr;
@@ -194,9 +173,6 @@ void Optimizer::loadMotionModels()
 
 void Optimizer::loadSensorModels()
 {
-  const std::string param_prefix = "sensor_models.";
-  const std::string list_param_full_name = param_prefix + "sensor_model_list";
-
   // struct for readability
   typedef struct {
     std::string name;
@@ -211,36 +187,17 @@ void Optimizer::loadSensorModels()
   // the configurations used to load models
   std::vector<ModelConfig> sensor_model_config;
 
-  // declare the parameter
-  if(! interfaces_.get_node_parameters_interface()->has_parameter(list_param_full_name)){
-    rcl_interfaces::msg::ParameterDescriptor descr;
-    descr.description = "the list of sensor models to load";
-    interfaces_.get_node_parameters_interface()->declare_parameter(
-      list_param_full_name,
-      rclcpp::ParameterValue (std::vector< std::string >()),
-      descr
-    );
-    // XXX catch rclcpp::exceptions::InvalidParameterValueException when launch assigns wrong type
-  }
-
-  // get the list of sensor models
-  rclcpp::Parameter sensor_model_list_param = interfaces_.get_node_parameters_interface()->get_parameter(list_param_full_name);
-
-  //extract the list from the parameter
-  if(sensor_model_list_param.get_type() == rclcpp::ParameterType::PARAMETER_STRING_ARRAY){
-    std::vector< std::string > names = sensor_model_list_param.as_string_array();
-    for(std::string name : names){
-      ModelConfig config;
-      config.name = name;
-      sensor_model_config.push_back(std::move(config));
-    }
-  }
+  std::unordered_set<std::string> sensor_model_names =
+    fuse_core::list_parameter_overrides_at_prefix(
+      interfaces_, "sensor_models.", 1);
 
   // declare config parameters for each model
-  for(ModelConfig & config : sensor_model_config){
-    config.type_param_name = param_prefix + config.name + ".type";
-    config.models_param_name = param_prefix + config.name + ".motion_models";
-    config.ignition_param_name = param_prefix + config.name + ".ignition";
+  for(const auto & param_name : sensor_model_names){
+    ModelConfig & config = sensor_model_config.emplace_back();
+    config.name = param_name.substr(param_name.rfind('.') + 1);
+    config.type_param_name = param_name + ".type";
+    config.models_param_name = param_name + ".motion_models";
+    config.ignition_param_name = param_name + ".ignition";
 
 
     // get the type parameter for the sensor model
@@ -343,10 +300,6 @@ void Optimizer::loadSensorModels()
 
 void Optimizer::loadPublishers()
 {
-
-  const std::string param_prefix = "publishers.";
-  const std::string list_param_full_name = param_prefix + "publisher_list";
-
   // struct for readability
   typedef struct {
     std::string name;
@@ -357,34 +310,15 @@ void Optimizer::loadPublishers()
   // the configurations used to load models
   std::vector<PublisherConfig> publisher_config;
 
-  // declare the parameter
-  if(! interfaces_.get_node_parameters_interface()->has_parameter(list_param_full_name)){
-    rcl_interfaces::msg::ParameterDescriptor descr;
-    descr.description = "the list of publishers to load";
-    interfaces_.get_node_parameters_interface()->declare_parameter(
-      list_param_full_name,
-      rclcpp::ParameterValue (std::vector< std::string >()),
-      descr
-    );
-    // XXX catch rclcpp::exceptions::InvalidParameterValueException when launch assigns wrong type
-  }
-
-  // get the list of publishers
-  rclcpp::Parameter publisher_list_param = interfaces_.get_node_parameters_interface()->get_parameter(list_param_full_name);
-
-  //extract the list from the parameter
-  if(publisher_list_param.get_type() == rclcpp::ParameterType::PARAMETER_STRING_ARRAY){
-    std::vector< std::string > names = publisher_list_param.as_string_array();
-    for(std::string name : names){
-      PublisherConfig config;
-      config.name = name;
-      publisher_config.push_back(std::move(config));
-    }
-  }
+  std::unordered_set<std::string> publisher_names =
+    fuse_core::list_parameter_overrides_at_prefix(
+      interfaces_, "publishers.", 1);
 
   // declare config parameters for each model
-  for(PublisherConfig & config : publisher_config){
-    config.param_name = param_prefix + config.name + ".type";
+  for(const auto & param_name : publisher_names){
+    PublisherConfig & config = publisher_config.emplace_back();
+    config.name = param_name.substr(param_name.rfind('.') + 1);
+    config.param_name = param_name + ".type";
 
     if(! interfaces_.get_node_parameters_interface()->has_parameter(config.param_name)){
       rcl_interfaces::msg::ParameterDescriptor descr;

--- a/fuse_optimizers/src/optimizer.cpp
+++ b/fuse_optimizers/src/optimizer.cpp
@@ -121,8 +121,8 @@ void Optimizer::loadMotionModels()
   std::vector<ModelConfig> motion_model_config;
 
   std::unordered_set<std::string> motion_model_names =
-    fuse_core::list_parameter_overrides_at_prefix(
-      interfaces_, "motion_models.", 1);
+    fuse_core::list_parameter_override_prefixes(
+      interfaces_, "motion_models.");
 
   // declare config parameters for each model
   for(const auto & param_name : motion_model_names){
@@ -188,8 +188,8 @@ void Optimizer::loadSensorModels()
   std::vector<ModelConfig> sensor_model_config;
 
   std::unordered_set<std::string> sensor_model_names =
-    fuse_core::list_parameter_overrides_at_prefix(
-      interfaces_, "sensor_models.", 1);
+    fuse_core::list_parameter_override_prefixes(
+      interfaces_, "sensor_models.");
 
   // declare config parameters for each model
   for(const auto & param_name : sensor_model_names){
@@ -311,8 +311,8 @@ void Optimizer::loadPublishers()
   std::vector<PublisherConfig> publisher_config;
 
   std::unordered_set<std::string> publisher_names =
-    fuse_core::list_parameter_overrides_at_prefix(
-      interfaces_, "publishers.", 1);
+    fuse_core::list_parameter_override_prefixes(
+      interfaces_, "publishers.");
 
   // declare config parameters for each model
   for(const auto & param_name : publisher_names){

--- a/fuse_optimizers/test/launch_tests/config/fixed_lag_ignition_params.yaml
+++ b/fuse_optimizers/test/launch_tests/config/fixed_lag_ignition_params.yaml
@@ -10,18 +10,11 @@ fixed_lag_node:
 
 
       motion_models:
-        motion_model_list:
-          - unicycle_motion_model
-
         unicycle_motion_model:
           type: fuse_models::Unicycle2D
 
 
       sensor_models:
-        sensor_model_list:
-          - unicycle_ignition_sensor
-          - pose_sensor
-
         unicycle_ignition_sensor:
           type: fuse_models::Unicycle2DIgnition
           motion_models: [unicycle_motion_model]
@@ -32,8 +25,6 @@ fixed_lag_node:
 
 
       publishers:
-        publisher_list:
-          - odometry_publisher
 
         odometry_publisher:
           type: fuse_models::Odometry2DPublisher

--- a/fuse_optimizers/test/launch_tests/config/optimizer_params.yaml
+++ b/fuse_optimizers/test/launch_tests/config/optimizer_params.yaml
@@ -1,10 +1,6 @@
 example_optimizer_node:
   ros__parameters:
     motion_models:
-      motion_model_list:
-        - unicycle_2d
-        - noisy_unicycle_2d
-
       noisy_unicycle_2d:
         type: fuse_models::Unicycle2D
 
@@ -13,12 +9,6 @@ example_optimizer_node:
 
 
     sensor_models:
-      sensor_model_list:
-        - unicycle_2d_ignition
-        - wheel_odometry
-        - laser_localization
-        - imu
-
       unicycle_2d_ignition:
         type: fuse_models::Unicycle2DIgnition
         motion_models: ['unicycle_2d']
@@ -34,9 +24,6 @@ example_optimizer_node:
 
 
     publishers:
-      publisher_list:
-        - odometry_publisher
-        - serialized_publisher
 
       odometry_publisher:
         type: fuse_models::Odometry2DPublisher


### PR DESCRIPTION
This adds a helper function to fuse_core (which should really be upstreamed to rclcpp) that allows discovering parameters at a given prefix without declaring them. It the uses that new function to avoid needing new parameters for the list of sensor models, motion models, and publishers.

@methylDragon 